### PR TITLE
Match CSV header line symbols with emitted values order

### DIFF
--- a/lib/git_time_extractor.rb
+++ b/lib/git_time_extractor.rb
@@ -200,8 +200,8 @@ class GitTimeExtractor
     [
       # 'From Date',
       # 'To Date',
-      'Total Git Commits Count',
       'Total Hours',
+      'Total Git Commits Count',
       'Collaborators',
     ]
   end # summary_header_row_template


### PR DESCRIPTION
When given option '--project-total', the program emits:

	<hours>, <commits>, <authors>

Prior to this commit, the header line had hours and commits in reverse order. This commit fixes the header line's order.